### PR TITLE
[FEAT] 카테고리 UI 퍼블리싱(Closes #5)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+node_modules
+
+**/.vite/

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -20,6 +20,7 @@
     "react-dom": "^19.2.0",
     "react-router": "^7.13.0",
     "tailwind-merge": "^3.5.0",
+    "tailwind-scrollbar-hide": "^4.0.0",
     "zustand": "^5.0.11"
   },
   "devDependencies": {

--- a/apps/web/src/features/category/components/CategoryAccordion.tsx
+++ b/apps/web/src/features/category/components/CategoryAccordion.tsx
@@ -1,0 +1,56 @@
+import { useState } from 'react';
+import { Link } from 'react-router';
+import { CategoryType } from '@somesay/shared';
+import MainArrowIcon from '@/shared/icons/MainArrowIcon.svg?react';
+
+interface CategoryAccordionProps {
+  category: CategoryType;
+}
+
+export const CategoryAccordion = ({ category }: CategoryAccordionProps) => {
+  const [isOpen, setIsOpen] = useState(false);
+
+  const subListId = `subcategory-list-${category.id}`;
+
+  const toggleAccordion = () => {
+    setIsOpen((prev) => !prev);
+  };
+
+  return (
+    <li className="list-none">
+      <div className="flex items-center px-4">
+        <button
+          type="button"
+          onClick={toggleAccordion}
+          aria-expanded={isOpen}
+          aria-controls={subListId}
+          className="flex w-full cursor-pointer items-center justify-between"
+        >
+          <div className="flex items-center gap-3">
+            {/* TODO: 나중에 실제 카테고리 아이콘으로 교체 */}
+            <div className="bg-grey04 h-9 w-9 rounded-full" />
+            <span className="body1-sb">{category.title}</span>
+          </div>
+        </button>
+        {/* TODO: 나중에 대분류 페이지로 이동 */}
+        <Link to={`/`} aria-label={`${category.title} 전체보기 페이지로 이동`}>
+          <MainArrowIcon />
+        </Link>
+      </div>
+      {/* 소분류 목록 렌더링 */}
+
+      <ul
+        id={subListId}
+        role="region"
+        className={`flex flex-col gap-6 px-8 pt-6 ${!isOpen ? 'hidden' : ''}`}
+      >
+        {category.subCategories.map((sub) => (
+          <li key={sub.id} className="body2-m cursor-pointer">
+            {sub.name}
+          </li>
+        ))}
+      </ul>
+      <hr className="border-grey03 mx-4 my-7 border-t" aria-hidden="true" />
+    </li>
+  );
+};

--- a/apps/web/src/pages/category/CategoriesPage.tsx
+++ b/apps/web/src/pages/category/CategoriesPage.tsx
@@ -1,0 +1,73 @@
+import { CategoryAccordion } from '@/features/category/components/CategoryAccordion';
+import { CategoryType } from '@somesay/shared';
+
+// 임시 Mock 데이터
+const CATEGORY_MOCK_DATA: CategoryType[] = [
+  {
+    id: 1,
+    title: '스킨케어',
+    subCategories: [
+      { id: 101, name: '스킨/토너' },
+      { id: 102, name: '로션/에멀전' },
+      { id: 103, name: '에센스/앰플/세럼' },
+      { id: 104, name: '크림' },
+      { id: 105, name: '미스트/오일' },
+    ],
+  },
+  {
+    id: 2,
+    title: '클렌징',
+    subCategories: [
+      { id: 201, name: '클렌징 폼' },
+      { id: 202, name: '클렌징 오일' },
+      { id: 203, name: '클렌징 밤' },
+      { id: 204, name: '클렌징 워터/밀크' },
+      { id: 205, name: '필링/스크럽' },
+    ],
+  },
+  {
+    id: 3,
+    title: '마스크/팩',
+    subCategories: [
+      { id: 301, name: '시트 마스크' },
+      { id: 302, name: '스킨/토너 패드' },
+      { id: 303, name: '코팩' },
+      { id: 304, name: '기타 마스크' },
+    ],
+  },
+  {
+    id: 4,
+    title: '선케어',
+    subCategories: [
+      { id: 401, name: '선크림' },
+      { id: 402, name: '선앰플' },
+    ],
+  },
+  {
+    id: 5,
+    title: '베이스 메이크업',
+    subCategories: [
+      { id: 501, name: '메이크업 베이스' },
+      { id: 502, name: '쿠션' },
+      { id: 503, name: '파운데이션' },
+    ],
+  },
+];
+
+export const CategoriesPage = () => {
+  return (
+    <>
+      <header className="flex h-13.5 w-full items-center justify-center bg-white px-4 py-2.5">
+        <h1 className="body1-sb">카테고리</h1>
+      </header>
+
+      <div className="pt-5">
+        <ul className="flex flex-col">
+          {CATEGORY_MOCK_DATA.map((category) => (
+            <CategoryAccordion key={category.id} category={category} />
+          ))}
+        </ul>
+      </div>
+    </>
+  );
+};

--- a/apps/web/src/routes/index.tsx
+++ b/apps/web/src/routes/index.tsx
@@ -2,6 +2,7 @@ import { createBrowserRouter } from 'react-router';
 import { PATH } from '@/routes/path';
 
 import { HomePage } from '@/pages/home/HomePage';
+import { CategoriesPage } from '@/pages/category/CategoriesPage';
 import { GlobalLayout } from '@/shared/components';
 
 export const appRouter = createBrowserRouter([
@@ -12,6 +13,10 @@ export const appRouter = createBrowserRouter([
     children: [
       { index: true, element: <HomePage /> }, // "/" 접속 시 홈페이지 렌더링
       // ...authRoutes, 추후 추가
+      {
+        path: PATH.CATEGORIES.BASE,
+        element: <CategoriesPage />,
+      },
     ],
   },
 ]);

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "lint-staged": "^16.2.7",
     "prettier": "^3.8.1",
     "prettier-plugin-tailwindcss": "^0.7.2",
-    "turbo": "^2.8.3"
+    "turbo": "^2.8.3",
+    "vite-plugin-svgr": "^4.5.0"
   },
   "lint-staged": {
     "*.{ts,tsx}": [

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -8,3 +8,5 @@
 //예 export type { User, ApiResponse } from "./types/common";
 // Utils
 //예 export { formatDate, formatPrice } from "./utils/format";
+
+export * from './types/category.types';

--- a/packages/shared/src/types/category.types.ts
+++ b/packages/shared/src/types/category.types.ts
@@ -1,0 +1,10 @@
+export interface SubCategoryType {
+  id: number;
+  name: string;
+}
+
+export interface CategoryType {
+  id: number;
+  title: string;
+  subCategories: SubCategoryType[];
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -46,6 +46,9 @@ importers:
       turbo:
         specifier: ^2.8.3
         version: 2.8.3
+      vite-plugin-svgr:
+        specifier: ^4.5.0
+        version: 4.5.0(rollup@4.57.1)(typescript@5.9.3)(vite@7.3.1(@types/node@24.10.12)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2))
 
   apps/web:
     dependencies:
@@ -76,6 +79,9 @@ importers:
       tailwind-merge:
         specifier: ^3.5.0
         version: 3.5.0
+      tailwind-scrollbar-hide:
+        specifier: ^4.0.0
+        version: 4.0.0(tailwindcss@4.1.18)
       zustand:
         specifier: ^5.0.11
         version: 5.0.11(@types/react@19.2.13)(react@19.2.4)(use-sync-external-store@1.6.0(react@19.2.4))
@@ -3917,6 +3923,14 @@ packages:
         integrity: sha512-I8K9wewnVDkL1NTGoqWmVEIlUcB9gFriAEkXkfCjX5ib8ezGxtR3xD7iZIxrfArjEsH7F1CHD4RFUtxefdqV/A==,
       }
 
+  tailwind-scrollbar-hide@4.0.0:
+    resolution:
+      {
+        integrity: sha512-gobtvVcThB2Dxhy0EeYSS1RKQJ5baDFkamkhwBvzvevwX6L4XQfpZ3me9s25Ss1ecFVT5jPYJ50n+7xTBJG9WQ==,
+      }
+    peerDependencies:
+      tailwindcss: '>=3.0.0 || >= 4.0.0 || >= 4.0.0-beta.8 || >= 4.0.0-alpha.20'
+
   tailwindcss@4.1.18:
     resolution:
       {
@@ -6583,6 +6597,10 @@ snapshots:
   svg-parser@2.0.4: {}
 
   tailwind-merge@3.5.0: {}
+
+  tailwind-scrollbar-hide@4.0.0(tailwindcss@4.1.18):
+    dependencies:
+      tailwindcss: 4.1.18
 
   tailwindcss@4.1.18: {}
 


### PR DESCRIPTION
## 개요
카테고리 목록 페이지를 신규 구현하고, 웹 접근성(WAI-ARIA) 가이드를 준수하여 아코디언 컴포넌트를 최적화했습니다. 단순 기능 구현을 넘어, 시멘틱 마크업과 SPA 전환 최적화를 통해 사용자 경험을 개선했습니다.

## 관련 이슈
Resolves: #5

## PR 유형
어떤 변경 사항이 있나요?

- [x] ✨ 새로운 기능 추가  
- [ ] 🐛 버그 수정  
- [x] 🎨 UI / 스타일 변경 (CSS 등)  
- [ ] 📝 문서 수정  
- [x] 🔧 코드 리팩토링  
- [ ] 🧪 테스트 코드 추가 / 수정  
- [ ] 💬 주석 추가 / 수정  
- [x] 🧹 코드 외 변경사항 (예: 오타, 탭 사이즈, 변수명 변경 등)  
- [x] 📦 빌드 설정 / 패키지 매니저 수정  
- [x] 📁 파일 또는 폴더명 수정  
- [ ] 🗑️ 파일 또는 폴더 삭제  

## 작업 내용
- 도메인 기반 페이지 구현: React + Vite 환경에서 카테고리 도메인 전용 페이지 및 라우팅 환경 구축
- 카테고리 컴포넌트 설계: 접근성 표준 속성을 적용한 아코디언 컴포넌트 구현

## 스크린샷/동영상
<img width="551" height="903" alt="image" src="https://github.com/user-attachments/assets/92572921-4fad-4dd5-be10-8b23b323656b" />
<img width="545" height="904" alt="image" src="https://github.com/user-attachments/assets/9b752834-c2ed-4c38-a86a-7e22f98ae692" />


## 공유사항
```tsx
<Link to={`/`} aria-label={`${category.title} 전체보기 페이지로 이동`}>
  <MainArrowIcon />
</Link>
```
- **Link 컴포넌트 활용**: `MainArrowIcon` 클릭 시 새로고침 없는 페이지 전환을 위해 `<a>` 대신 `Link` 컴포넌트를 사용했습니다. 이 방식이 프로젝트의 라우팅 컨벤션에 부합하는지 리뷰 부탁드립니다.
- **WAI-ARIA 적용 적절성**: 현재 스크린 리더 사용자를 위해 `aria-label`을 포함한 필수 속성들을 적용해 두었습니다. 혹시 추가로 보완이 필요한 접근성 속성이 있다면 의견 주시면 감사하겠습니다!
