### PR TITLE
[CHORE] 홈 1.2 '제품군' -> '카테고리' 변경 및 카테고리 일관성 (Closes #23)

### DIFF
--- a/apps/web/src/features/category/components/CategoryAccordion.tsx
+++ b/apps/web/src/features/category/components/CategoryAccordion.tsx
@@ -1,16 +1,16 @@
 import { useState } from 'react';
 import { Link } from 'react-router';
-import { CategoryType } from '@somesay/shared';
+import { SubcategoryGroup } from '@somesay/shared';
 import { MainArrowIcon } from '@/shared/icons';
 
 interface CategoryAccordionProps {
-  category: CategoryType;
+  category: SubcategoryGroup;
 }
 
 export const CategoryAccordion = ({ category }: CategoryAccordionProps) => {
   const [isOpen, setIsOpen] = useState(false);
 
-  const subListId = `subcategory-list-${category.id}`;
+  const subListId = `subcategory-list-${category.categoryId}`;
 
   const toggleAccordion = () => {
     setIsOpen((prev) => !prev);
@@ -29,11 +29,14 @@ export const CategoryAccordion = ({ category }: CategoryAccordionProps) => {
           <div className="flex items-center gap-3">
             {/* TODO: 나중에 실제 카테고리 아이콘으로 교체 */}
             <div className="bg-grey04 h-9 w-9 rounded-full" />
-            <span className="body1-sb">{category.title}</span>
+            <span className="body1-sb">{category.categoryLabel}</span>
           </div>
         </button>
         {/* TODO: 나중에 대분류 페이지로 이동 */}
-        <Link to={`/`} aria-label={`${category.title} 전체보기 페이지로 이동`}>
+        <Link
+          to={`/`}
+          aria-label={`${category.categoryLabel} 전체보기 페이지로 이동`}
+        >
           <MainArrowIcon />
         </Link>
       </div>
@@ -44,9 +47,9 @@ export const CategoryAccordion = ({ category }: CategoryAccordionProps) => {
         role="region"
         className={`flex flex-col gap-6 px-8 pt-6 ${!isOpen ? 'hidden' : ''}`}
       >
-        {category.subCategories?.map((sub) => (
-          <li key={sub.id} className="body2-m cursor-pointer">
-            {sub.name}
+        {category.subcategories.map((sub) => (
+          <li key={sub.subCategoryId} className="body2-m cursor-pointer">
+            {sub.label}
           </li>
         ))}
       </ul>

--- a/apps/web/src/features/home/components/categoryProducts/CategoryProductSection.tsx
+++ b/apps/web/src/features/home/components/categoryProducts/CategoryProductSection.tsx
@@ -11,7 +11,11 @@ export const CategoryProductSection = () => {
   // const { data: products = [] } = useCategoryProducts(selectedCategoryId);
 
   //TODO: 임시
-  const categories = CATEGORIES;
+  const categories = CATEGORIES.map((category) => ({
+    id: category.categoryId,
+    label: category.categoryLabel,
+  }));
+
   const products =
     MOCK_CATEGORY_PRODUCTS.find(
       (category) => category.categoryId === selectedCategoryId

--- a/apps/web/src/features/home/components/categoryProducts/CategoryProductSection.tsx
+++ b/apps/web/src/features/home/components/categoryProducts/CategoryProductSection.tsx
@@ -1,16 +1,8 @@
 import { useState } from 'react';
 import { HorizontalCategoriesTab } from '@/shared/components/category/HorizontalCategoriesTab';
 import { BasicProductCard, MoreButton } from '@/shared/components';
-import { CategoryType } from '@somesay/shared';
+import { CATEGORIES } from '@somesay/shared';
 import { MOCK_CATEGORY_PRODUCTS } from './mockData';
-
-const CATEGORIES: CategoryType[] = [
-  { id: 1, title: '전체' },
-  { id: 2, title: '클렌징/필링' },
-  { id: 3, title: '마스크/팩' },
-  { id: 4, title: '선케어' },
-  { id: 5, title: '베이스' },
-];
 
 export const CategoryProductSection = () => {
   const [selectedCategoryId, setSelectedCategoryId] = useState(1);
@@ -62,7 +54,7 @@ export const CategoryProductSection = () => {
         {/* 더보기 버튼 */}
         <MoreButton
           to={'/임시'}
-          text={`${CATEGORIES.find((c) => c.id === selectedCategoryId)?.title === '전체' ? '' : CATEGORIES.find((c) => c.id === selectedCategoryId)?.title} 상품 더보기`}
+          text={`${CATEGORIES.find((c) => c.categoryId === selectedCategoryId)?.categoryLabel === '전체' ? '' : CATEGORIES.find((c) => c.categoryId === selectedCategoryId)?.categoryLabel} 상품 더보기`}
         />
       </div>
     </section>

--- a/apps/web/src/features/home/components/categoryProducts/mockData.ts
+++ b/apps/web/src/features/home/components/categoryProducts/mockData.ts
@@ -6,11 +6,11 @@ import mockProfile3Img from '@/assets/mock_profile3_img.png';
 import mockProductImg from '@/assets/mock_product_img.png';
 
 export const CATEGORIES: CategoryType[] = [
-  { id: 1, title: '전체' },
-  { id: 2, title: '클렌징/필링' },
-  { id: 3, title: '마스크/팩' },
-  { id: 4, title: '선케어' },
-  { id: 5, title: '베이스' },
+  { categoryId: 1, categoryLabel: '전체' },
+  { categoryId: 2, categoryLabel: '클렌징/필링' },
+  { categoryId: 3, categoryLabel: '마스크/팩' },
+  { categoryId: 4, categoryLabel: '선케어' },
+  { categoryId: 5, categoryLabel: '베이스' },
 ];
 
 // features/home/mocks/categoryProducts.mock.ts

--- a/apps/web/src/features/home/components/categoryProducts/mockData.ts
+++ b/apps/web/src/features/home/components/categoryProducts/mockData.ts
@@ -1,19 +1,7 @@
-// features/home/mocks/categories.mock.ts
-import { CategoryType } from '@somesay/shared';
 import mockProfileImg from '@/assets/mock_profile_img.svg';
 import mockProfile2Img from '@/assets/mock_profile2_img.png';
 import mockProfile3Img from '@/assets/mock_profile3_img.png';
 import mockProductImg from '@/assets/mock_product_img.png';
-
-export const CATEGORIES: CategoryType[] = [
-  { categoryId: 1, categoryLabel: '전체' },
-  { categoryId: 2, categoryLabel: '클렌징/필링' },
-  { categoryId: 3, categoryLabel: '마스크/팩' },
-  { categoryId: 4, categoryLabel: '선케어' },
-  { categoryId: 5, categoryLabel: '베이스' },
-];
-
-// features/home/mocks/categoryProducts.mock.ts
 import { ProductCardType, ProductsByCategory } from '@somesay/shared';
 
 const MOCK_CREATORS = [

--- a/apps/web/src/features/home/components/productRecommendation/FilterBottomSheet.tsx
+++ b/apps/web/src/features/home/components/productRecommendation/FilterBottomSheet.tsx
@@ -5,8 +5,14 @@ import { FilterCategoryTab, CTAButton } from '@/shared/components';
 import {
   SKIN_CONCERN_OPTIONS,
   SKIN_TYPE_OPTIONS,
-  PRODUCT_SUB_CATEGORY_GROUPS,
+  CATEGORY_GROUPS,
 } from '@somesay/shared';
+import type { SubcategoryOption } from '@somesay/shared';
+
+const ALL_SUBCATEGORY_OPTION: SubcategoryOption = {
+  subCategoryId: 0,
+  label: '전체',
+};
 
 interface FilterBottomSheetProps {
   isOpen: boolean;
@@ -144,36 +150,36 @@ export const FilterBottomSheet = ({
               role="group"
               aria-label="카테고리 선택"
             >
-              {PRODUCT_SUB_CATEGORY_GROUPS.map((subCategory) => {
-                const firstItem = subCategory.subcategories[0];
-                return subCategory.categoryLabel === '전체' && firstItem ? (
-                  <FilterChip
-                    key={firstItem.subCategoryId}
-                    label={firstItem.label}
-                    selected={selectedFilters.category.includes(firstItem)}
-                    onClick={() => handleToggleFilter(firstItem)}
-                  />
-                ) : (
-                  <div
-                    className="flex w-full flex-col items-start gap-3 self-stretch"
-                    key={subCategory.categoryLabel}
-                  >
-                    <p className="body2-sb text-black">
-                      {subCategory.categoryLabel}
-                    </p>
-                    <div className="flex flex-wrap content-start items-start gap-x-2 gap-y-3 self-stretch">
-                      {subCategory.subcategories.map((filter) => (
-                        <FilterChip
-                          key={filter.subCategoryId}
-                          label={filter.label}
-                          selected={selectedFilters.category.includes(filter)}
-                          onClick={() => handleToggleFilter(filter)}
-                        />
-                      ))}
-                    </div>
+              {/* 전체 */}
+              <FilterChip
+                key={ALL_SUBCATEGORY_OPTION.subCategoryId}
+                label={ALL_SUBCATEGORY_OPTION.label}
+                selected={selectedFilters.category.some(
+                  (f) =>
+                    f.subCategoryId === ALL_SUBCATEGORY_OPTION.subCategoryId
+                )}
+                onClick={() => handleToggleFilter(ALL_SUBCATEGORY_OPTION)}
+              />
+
+              {/* 스킨케어, 마스크/팩, 클렌징 등 카테고리 그룹과 하위 카테고리를 맵핑하여 렌더링 */}
+              {CATEGORY_GROUPS.map((group) => (
+                <div
+                  className="flex w-full flex-col items-start gap-3 self-stretch"
+                  key={group.categoryId}
+                >
+                  <p className="body2-sb text-black">{group.categoryLabel}</p>
+                  <div className="flex flex-wrap content-start items-start gap-x-2 gap-y-3 self-stretch">
+                    {group.subcategories.map((filter) => (
+                      <FilterChip
+                        key={filter.subCategoryId}
+                        label={filter.label}
+                        selected={selectedFilters.category.includes(filter)}
+                        onClick={() => handleToggleFilter(filter)}
+                      />
+                    ))}
                   </div>
-                );
-              })}
+                </div>
+              ))}
             </div>
           </div>
         )}

--- a/apps/web/src/features/home/components/productRecommendation/FilterBottomSheet.tsx
+++ b/apps/web/src/features/home/components/productRecommendation/FilterBottomSheet.tsx
@@ -134,10 +134,10 @@ export const FilterBottomSheet = ({
             </div>
           </div>
         )}
-        {activeCategory === 'productCategory' && (
+        {activeCategory === 'category' && (
           <div className="flex flex-col items-start gap-3 px-4">
             <p className="body2-m text-grey06">
-              최대 {MAX_SELECTIONS.productCategory}개 선택
+              최대 {MAX_SELECTIONS.category}개 선택
             </p>
             <div
               className="flex flex-wrap content-start items-start gap-y-8 self-stretch"
@@ -150,9 +150,7 @@ export const FilterBottomSheet = ({
                   <FilterChip
                     key={firstItem.subCategoryId}
                     label={firstItem.label}
-                    selected={selectedFilters.productCategory.includes(
-                      firstItem
-                    )}
+                    selected={selectedFilters.category.includes(firstItem)}
                     onClick={() => handleToggleFilter(firstItem)}
                   />
                 ) : (
@@ -168,9 +166,7 @@ export const FilterBottomSheet = ({
                         <FilterChip
                           key={filter.subCategoryId}
                           label={filter.label}
-                          selected={selectedFilters.productCategory.includes(
-                            filter
-                          )}
+                          selected={selectedFilters.category.includes(filter)}
                           onClick={() => handleToggleFilter(filter)}
                         />
                       ))}

--- a/apps/web/src/features/home/components/productRecommendation/FilterBottomSheet.tsx
+++ b/apps/web/src/features/home/components/productRecommendation/FilterBottomSheet.tsx
@@ -142,7 +142,7 @@ export const FilterBottomSheet = ({
             <div
               className="flex flex-wrap content-start items-start gap-y-8 self-stretch"
               role="group"
-              aria-label="제품군 선택"
+              aria-label="카테고리 선택"
             >
               {PRODUCT_SUB_CATEGORY_GROUPS.map((subCategory) => {
                 const firstItem = subCategory.subcategories[0];

--- a/apps/web/src/features/home/components/productRecommendation/RecommendationSection.tsx
+++ b/apps/web/src/features/home/components/productRecommendation/RecommendationSection.tsx
@@ -8,7 +8,7 @@ import type { FilterCategoryType, SelectedFiltersType } from './filter.types';
 export const RecommendationSection = () => {
   const [isBottomSheetOpen, setIsBottomSheetOpen] = useState(false);
 
-  // 현재 활성화된 필터 카테고리 (피부고민, 피부타입, 제품군 중 하나)
+  // 현재 활성화된 필터 카테고리 (피부고민, 피부타입, 카테고리 중 하나)
   const [activeCategory, setActiveCategory] =
     useState<FilterCategoryType>('skinConcern');
 
@@ -16,7 +16,7 @@ export const RecommendationSection = () => {
   const [selectedFilters, setSelectedFilters] =
     useState<SelectedFiltersType>(INITIAL_FILTERS);
 
-  // (피부고민 피부타입 제품군) 중 하나 선택하면 해당 카테고리의 필터 시트 열기
+  // (피부고민 피부타입 카테고리) 중 하나 선택하면 해당 카테고리의 필터 시트 열기
   const handleOpenBottomSheet = (filter: FilterCategoryType) => {
     setActiveCategory(filter);
     setIsBottomSheetOpen(true);

--- a/apps/web/src/features/home/components/productRecommendation/RecommendationSection.tsx
+++ b/apps/web/src/features/home/components/productRecommendation/RecommendationSection.tsx
@@ -50,6 +50,7 @@ export const RecommendationSection = () => {
           <br />딱 맞는 제품을 추천해 드려요
         </h2>
         <div className="flex flex-col items-start gap-6 self-stretch">
+          {/* 피부고민, 피부 타입, 카테고리 행 */}
           <div
             role="group"
             aria-label="나의 피부 정보"

--- a/apps/web/src/features/home/components/productRecommendation/filter.constants.ts
+++ b/apps/web/src/features/home/components/productRecommendation/filter.constants.ts
@@ -6,15 +6,15 @@ export const FILTER_CATEGORIES: {
 }[] = [
   { category: 'skinConcern', label: '피부 고민' },
   { category: 'skinType', label: '피부 타입' },
-  { category: 'productCategory', label: '카테고리' },
+  { category: 'category', label: '카테고리' },
 ];
 export const INITIAL_FILTERS: SelectedFiltersType = {
   skinConcern: [],
   skinType: [],
-  productCategory: [],
+  category: [],
 };
 export const MAX_SELECTIONS: Record<FilterCategoryType, number> = {
   skinConcern: 2,
   skinType: 1,
-  productCategory: 1,
+  category: 1,
 };

--- a/apps/web/src/features/home/components/productRecommendation/filter.constants.ts
+++ b/apps/web/src/features/home/components/productRecommendation/filter.constants.ts
@@ -6,7 +6,7 @@ export const FILTER_CATEGORIES: {
 }[] = [
   { category: 'skinConcern', label: '피부 고민' },
   { category: 'skinType', label: '피부 타입' },
-  { category: 'productCategory', label: '제품군' },
+  { category: 'productCategory', label: '카테고리' },
 ];
 export const INITIAL_FILTERS: SelectedFiltersType = {
   skinConcern: [],

--- a/apps/web/src/features/home/components/productRecommendation/filter.types.ts
+++ b/apps/web/src/features/home/components/productRecommendation/filter.types.ts
@@ -1,13 +1,13 @@
 import type {
   SkinConcernOption,
   SkinTypeOption,
-  ProductSubCategoryOption,
+  SubcategoryOption,
 } from '@somesay/shared';
 
-export type FilterCategoryType = 'skinConcern' | 'skinType' | 'productCategory';
+export type FilterCategoryType = 'skinConcern' | 'skinType' | 'category';
 
 export interface SelectedFiltersType {
   skinConcern: SkinConcernOption[];
   skinType: SkinTypeOption[];
-  productCategory: ProductSubCategoryOption[];
+  category: SubcategoryOption[];
 }

--- a/apps/web/src/features/subcategory/components/SubcategoryProductList.tsx
+++ b/apps/web/src/features/subcategory/components/SubcategoryProductList.tsx
@@ -4,19 +4,19 @@ import { MOCK_SUBCATEGORY_PRODUCTS } from '@/features/subcategory';
 
 interface SubcategoryProductListProps {
   categoryId: number;
-  selectedSubCategoryId: number;
+  selectedSubcategoryId: number;
 }
 
 export const SubcategoryProductList = ({
   categoryId,
-  selectedSubCategoryId,
+  selectedSubcategoryId,
 }: SubcategoryProductListProps) => {
   const [products, setProducts] = useState(MOCK_SUBCATEGORY_PRODUCTS);
 
   const filteredProducts =
-    selectedSubCategoryId === 0
+    selectedSubcategoryId === 0
       ? products.filter((p) => p.categoryId === categoryId)
-      : products.filter((p) => p.subCategoryId === selectedSubCategoryId);
+      : products.filter((p) => p.subCategoryId === selectedSubcategoryId);
 
   const handleHeartToggle = (productId: number) => {
     setProducts((prev) =>

--- a/apps/web/src/features/subcategory/index.ts
+++ b/apps/web/src/features/subcategory/index.ts
@@ -1,4 +1,3 @@
 export { SubcategoryProductList } from './components/SubcategoryProductList';
-export { SubcategorySortBar } from './components/subcategorySort/SubcategorySortBar';
 export type { SubcategoryProductType } from './components/mockData';
 export { MOCK_SUBCATEGORY_PRODUCTS } from './components/mockData';

--- a/apps/web/src/features/subcategory/index.ts
+++ b/apps/web/src/features/subcategory/index.ts
@@ -1,3 +1,4 @@
 export { SubcategoryProductList } from './components/SubcategoryProductList';
+export { SubcategorySortBar } from './components/subcategorySort/SubcategorySortBar';
 export type { SubcategoryProductType } from './components/mockData';
 export { MOCK_SUBCATEGORY_PRODUCTS } from './components/mockData';

--- a/apps/web/src/pages/category/CategoriesPage.tsx
+++ b/apps/web/src/pages/category/CategoriesPage.tsx
@@ -1,10 +1,6 @@
 import { CategoryAccordion } from '@/features/category/components/CategoryAccordion';
-import { PRODUCT_SUB_CATEGORY_GROUPS } from '@somesay/shared';
+import { CATEGORY_GROUPS } from '@somesay/shared';
 import { PageHeader } from '@/shared/components';
-
-const CATEGORIES = PRODUCT_SUB_CATEGORY_GROUPS.filter(
-  (group) => group.categoryId !== 0
-);
 
 export const CategoriesPage = () => {
   return (
@@ -12,7 +8,7 @@ export const CategoriesPage = () => {
       <PageHeader title="카테고리" />
       <div className="pt-5">
         <ul className="flex flex-col">
-          {CATEGORIES.map((category) => (
+          {CATEGORY_GROUPS.map((category) => (
             <CategoryAccordion key={category.categoryId} category={category} />
           ))}
         </ul>

--- a/apps/web/src/pages/category/CategoriesPage.tsx
+++ b/apps/web/src/pages/category/CategoriesPage.tsx
@@ -1,59 +1,10 @@
 import { CategoryAccordion } from '@/features/category/components/CategoryAccordion';
-import { CategoryType } from '@somesay/shared';
+import { PRODUCT_SUB_CATEGORY_GROUPS } from '@somesay/shared';
 import { PageHeader } from '@/shared/components';
 
-// 임시 Mock 데이터
-const CATEGORY_MOCK_DATA: CategoryType[] = [
-  {
-    id: 1,
-    title: '스킨케어',
-    subCategories: [
-      { id: 101, name: '스킨/토너' },
-      { id: 102, name: '로션/에멀전' },
-      { id: 103, name: '에센스/앰플/세럼' },
-      { id: 104, name: '크림' },
-      { id: 105, name: '미스트/오일' },
-    ],
-  },
-  {
-    id: 2,
-    title: '클렌징',
-    subCategories: [
-      { id: 201, name: '클렌징 폼' },
-      { id: 202, name: '클렌징 오일' },
-      { id: 203, name: '클렌징 밤' },
-      { id: 204, name: '클렌징 워터/밀크' },
-      { id: 205, name: '필링/스크럽' },
-    ],
-  },
-  {
-    id: 3,
-    title: '마스크/팩',
-    subCategories: [
-      { id: 301, name: '시트 마스크' },
-      { id: 302, name: '스킨/토너 패드' },
-      { id: 303, name: '코팩' },
-      { id: 304, name: '기타 마스크' },
-    ],
-  },
-  {
-    id: 4,
-    title: '선케어',
-    subCategories: [
-      { id: 401, name: '선크림' },
-      { id: 402, name: '선앰플' },
-    ],
-  },
-  {
-    id: 5,
-    title: '베이스 메이크업',
-    subCategories: [
-      { id: 501, name: '메이크업 베이스' },
-      { id: 502, name: '쿠션' },
-      { id: 503, name: '파운데이션' },
-    ],
-  },
-];
+const CATEGORIES = PRODUCT_SUB_CATEGORY_GROUPS.filter(
+  (group) => group.categoryId !== 0
+);
 
 export const CategoriesPage = () => {
   return (
@@ -61,8 +12,8 @@ export const CategoriesPage = () => {
       <PageHeader title="카테고리" />
       <div className="pt-5">
         <ul className="flex flex-col">
-          {CATEGORY_MOCK_DATA.map((category) => (
-            <CategoryAccordion key={category.id} category={category} />
+          {CATEGORIES.map((category) => (
+            <CategoryAccordion key={category.categoryId} category={category} />
           ))}
         </ul>
       </div>

--- a/apps/web/src/pages/category/SubcategoriesPage.tsx
+++ b/apps/web/src/pages/category/SubcategoriesPage.tsx
@@ -28,11 +28,11 @@ export const SubcategoriesPage = () => {
   );
   const categoryTitle = currentCategory?.categoryLabel ?? '';
 
-  const tabCategories = [
-    { id: 0, title: '전체' },
+  const tabSubcategories = [
+    { id: 0, label: '전체' },
     ...(currentCategory?.subcategories.map((sub) => ({
       id: sub.subCategoryId,
-      title: sub.label,
+      label: sub.label,
     })) ?? []),
   ];
 
@@ -64,7 +64,7 @@ export const SubcategoriesPage = () => {
       />
       <div className="px-4">
         <HorizontalCategoriesTab
-          categories={tabCategories}
+          categories={tabSubcategories}
           selectedId={selectedId}
           onSelect={setSelectedId}
           ariaLabel={`${categoryTitle} 소분류 카테고리`}

--- a/apps/web/src/pages/category/SubcategoriesPage.tsx
+++ b/apps/web/src/pages/category/SubcategoriesPage.tsx
@@ -8,28 +8,7 @@ import {
   SortBar,
 } from '@/shared/components';
 import { ArrowBackIcon, SearchIcon } from '@/shared/icons';
-
-const CATEGORY_MOCK_DATA = [
-  {
-    id: 1,
-    title: '스킨케어',
-    subcategories: [
-      { id: 101, name: '스킨/토너' },
-      { id: 102, name: '로션/에멀전' },
-      { id: 103, name: '에센스/앰플/세럼' },
-      { id: 104, name: '크림' },
-      { id: 105, name: '미스트/오일' },
-    ],
-  },
-  {
-    id: 2,
-    title: '클렌징',
-    subcategories: [
-      { id: 201, name: '클렌징 폼' },
-      { id: 202, name: '클렌징 오일' },
-    ],
-  },
-];
+import { PRODUCT_SUB_CATEGORY_GROUPS } from '@somesay/shared';
 
 const SORT_OPTIONS = [
   { value: 'rating', label: '평점순' },
@@ -44,14 +23,16 @@ export const SubcategoriesPage = () => {
   const [selectedId, setSelectedId] = useState(0);
   const [currentSortValue, setCurrentSortValue] = useState('rating');
 
-  const currentCategory = CATEGORY_MOCK_DATA.find((c) => c.id === categoryId);
-  const categoryTitle = currentCategory?.title ?? '';
+  const currentCategory = PRODUCT_SUB_CATEGORY_GROUPS.find(
+    (c) => c.categoryId === categoryId
+  );
+  const categoryTitle = currentCategory?.categoryLabel ?? '';
 
   const tabCategories = [
     { id: 0, title: '전체' },
-    ...(currentCategory?.subcategories?.map((sub) => ({
-      id: sub.id,
-      title: sub.name,
+    ...(currentCategory?.subcategories.map((sub) => ({
+      id: sub.subCategoryId,
+      title: sub.label,
     })) ?? []),
   ];
 
@@ -74,7 +55,7 @@ export const SubcategoriesPage = () => {
             <ArrowBackIcon aria-hidden="true" />
           </button>
         }
-        title={currentCategory?.title ?? ''}
+        title={currentCategory?.categoryLabel ?? ''}
         right={[
           <button type="button" aria-label="검색">
             <SearchIcon aria-hidden="true" />

--- a/apps/web/src/pages/category/SubcategoriesPage.tsx
+++ b/apps/web/src/pages/category/SubcategoriesPage.tsx
@@ -8,7 +8,7 @@ import {
   SortBar,
 } from '@/shared/components';
 import { ArrowBackIcon, SearchIcon } from '@/shared/icons';
-import { PRODUCT_SUB_CATEGORY_GROUPS } from '@somesay/shared';
+import { CATEGORY_GROUPS } from '@somesay/shared';
 
 const SORT_OPTIONS = [
   { value: 'rating', label: '평점순' },
@@ -23,7 +23,7 @@ export const SubcategoriesPage = () => {
   const [selectedId, setSelectedId] = useState(0);
   const [currentSortValue, setCurrentSortValue] = useState('rating');
 
-  const currentCategory = PRODUCT_SUB_CATEGORY_GROUPS.find(
+  const currentCategory = CATEGORY_GROUPS.find(
     (c) => c.categoryId === categoryId
   );
   const categoryTitle = currentCategory?.categoryLabel ?? '';

--- a/apps/web/src/pages/category/SubcategoriesPage.tsx
+++ b/apps/web/src/pages/category/SubcategoriesPage.tsx
@@ -100,7 +100,7 @@ export const SubcategoriesPage = () => {
       <div className="pt-6" />
       <SubcategoryProductList
         categoryId={categoryId}
-        selectedSubCategoryId={selectedId}
+        selectedSubcategoryId={selectedId}
       />
     </div>
   );

--- a/apps/web/src/pages/creatorHome/CreatorHomePage.tsx
+++ b/apps/web/src/pages/creatorHome/CreatorHomePage.tsx
@@ -62,7 +62,7 @@ export const CreatorHomePage = () => {
             <ShareIcon aria-hidden="true" />
           </Link>,
         ]}
-      />{' '}
+      />
       <div className="mb-7.5 flex flex-col gap-5 px-4 pt-2">
         <CreatorHomeProfile {...MOCK_CREATOR} />
         <CreatorHomeTrustScore {...MOCK_TRUST_SCORE} isLoggedIn={true} />

--- a/apps/web/src/pages/creatorHome/CreatorHomePage.tsx
+++ b/apps/web/src/pages/creatorHome/CreatorHomePage.tsx
@@ -10,20 +10,12 @@ import { CreatorHomeTrustScore } from '@/features/creatorHome';
 import { HorizontalCategoriesTab } from '@/shared/components';
 import { CreatorHomeReviewCard } from '@/shared/components';
 import { ArrowBackIcon, ShareIcon } from '@/shared/icons';
-import { CategoryType } from '@somesay/shared';
+import { CATEGORIES } from '@somesay/shared';
 import {
   MOCK_CREATOR,
   MOCK_TRUST_SCORE,
   MOCK_CREATOR_REVIEWS,
 } from '../../features/creatorHome/components/mockData';
-
-const CATEGORIES: CategoryType[] = [
-  { id: 1, title: '전체' },
-  { id: 2, title: '클렌징/필링' },
-  { id: 3, title: '마스크/팩' },
-  { id: 4, title: '선케어' },
-  { id: 5, title: '베이스' },
-];
 
 const SORT_OPTIONS = [
   { value: 'popular', label: '인기순' },
@@ -85,7 +77,10 @@ export const CreatorHomePage = () => {
           onClear={() => setSearchValue('')}
         />
         <HorizontalCategoriesTab
-          categories={CATEGORIES}
+          categories={CATEGORIES.map(({ categoryId, categoryLabel }) => ({
+            id: categoryId,
+            label: categoryLabel,
+          }))}
           selectedId={selectedCategoryId}
           onSelect={handleSelectCategory}
           ariaLabel="상품 카테고리"

--- a/apps/web/src/shared/components/category/HorizontalCategoriesTab.tsx
+++ b/apps/web/src/shared/components/category/HorizontalCategoriesTab.tsx
@@ -23,19 +23,19 @@ export const HorizontalCategoriesTab = ({
     >
       {categories.map((category) => (
         <button
-          key={category.id}
+          key={category.categoryId}
           role="tab"
           type="button"
-          aria-selected={selectedId === category.id}
-          onClick={() => onSelect(category.id)}
+          aria-selected={selectedId === category.categoryId}
+          onClick={() => onSelect(category.categoryId)}
           className={cn(
             'body2-m flex shrink-0 cursor-pointer items-center justify-center border border-solid px-3 py-1.5',
-            selectedId === category.id
+            selectedId === category.categoryId
               ? 'border-black text-black'
               : 'border-grey02 text-grey06'
           )}
         >
-          {category.title}
+          {category.categoryLabel}
         </button>
       ))}
     </div>

--- a/apps/web/src/shared/components/category/HorizontalCategoriesTab.tsx
+++ b/apps/web/src/shared/components/category/HorizontalCategoriesTab.tsx
@@ -1,9 +1,12 @@
 // 1.5 상품 목록의 카테고리 탭 컴포넌트
 import cn from '@/utils/cn';
-import { CategoryType } from '@somesay/shared';
 
+interface TabCategoryType {
+  id: number;
+  label: string;
+}
 interface HorizontalCategoriesTabProps {
-  categories: CategoryType[];
+  categories: TabCategoryType[];
   selectedId: number;
   onSelect: (id: number) => void;
   ariaLabel: string;
@@ -23,19 +26,19 @@ export const HorizontalCategoriesTab = ({
     >
       {categories.map((category) => (
         <button
-          key={category.categoryId}
+          key={category.id}
           role="tab"
           type="button"
-          aria-selected={selectedId === category.categoryId}
-          onClick={() => onSelect(category.categoryId)}
+          aria-selected={selectedId === category.id}
+          onClick={() => onSelect(category.id)}
           className={cn(
             'body2-m flex shrink-0 cursor-pointer items-center justify-center border border-solid px-3 py-1.5',
-            selectedId === category.categoryId
+            selectedId === category.id
               ? 'border-black text-black'
               : 'border-grey02 text-grey06'
           )}
         >
-          {category.categoryLabel}
+          {category.label}
         </button>
       ))}
     </div>

--- a/apps/web/src/shared/components/review/CreatorHomeReviewCard.tsx
+++ b/apps/web/src/shared/components/review/CreatorHomeReviewCard.tsx
@@ -52,7 +52,7 @@ export const CreatorHomeReviewCard = ({
         </p>
       </div>
       {/* 구분선 */}
-      <hr className="border-grey03 w-full px-4" />{' '}
+      <hr className="border-grey03 w-full px-4" />
     </article>
   );
 };

--- a/packages/shared/src/constants/cosmetics.constants.ts
+++ b/packages/shared/src/constants/cosmetics.constants.ts
@@ -1,7 +1,7 @@
 import type {
   SkinTypeOption,
   SkinConcernOption,
-  ProductSubCategoryGroup,
+  SubcategoryGroup,
 } from '../types/category.types';
 
 // TODO: skinConcernId는 백엔드 API 응답값으로 교체 필요
@@ -31,8 +31,8 @@ export const SKIN_TYPE_OPTIONS: SkinTypeOption[] = [
   { skinTypeId: 7, label: '모르겠음' },
 ];
 
-// ⚠️ productCategoryId는 백엔드 API 응답값으로 교체 필요
-export const PRODUCT_SUB_CATEGORY_GROUPS: ProductSubCategoryGroup[] = [
+// ⚠️ categoryId는 백엔드 API 응답값으로 교체 필요
+export const PRODUCT_SUB_CATEGORY_GROUPS: SubcategoryGroup[] = [
   {
     categoryLabel: '전체',
     subcategories: [{ subCategoryId: 1, label: '전체' }],

--- a/packages/shared/src/constants/cosmetics.constants.ts
+++ b/packages/shared/src/constants/cosmetics.constants.ts
@@ -2,6 +2,7 @@ import type {
   SkinTypeOption,
   SkinConcernOption,
   SubcategoryGroup,
+  CategoryType,
 } from '../types/category.types';
 
 // TODO: skinConcernId는 백엔드 API 응답값으로 교체 필요
@@ -31,13 +32,16 @@ export const SKIN_TYPE_OPTIONS: SkinTypeOption[] = [
   { skinTypeId: 7, label: '모르겠음' },
 ];
 
+export const CATEGORIES: CategoryType[] = [
+  { categoryId: 1, categoryLabel: '전체' },
+  { categoryId: 2, categoryLabel: '클렌징/필링' },
+  { categoryId: 3, categoryLabel: '마스크/팩' },
+  { categoryId: 4, categoryLabel: '선케어' },
+  { categoryId: 5, categoryLabel: '베이스' },
+];
+
 // ⚠️ categoryId, subCategoryId는 백엔드 API 응답값으로 교체 필요
-export const PRODUCT_SUB_CATEGORY_GROUPS: SubcategoryGroup[] = [
-  {
-    categoryId: 0,
-    categoryLabel: '전체',
-    subcategories: [{ subCategoryId: 1, label: '전체' }],
-  },
+export const CATEGORY_GROUPS: SubcategoryGroup[] = [
   {
     categoryId: 1,
     categoryLabel: '스킨케어',

--- a/packages/shared/src/constants/cosmetics.constants.ts
+++ b/packages/shared/src/constants/cosmetics.constants.ts
@@ -31,54 +31,60 @@ export const SKIN_TYPE_OPTIONS: SkinTypeOption[] = [
   { skinTypeId: 7, label: '모르겠음' },
 ];
 
-// ⚠️ categoryId는 백엔드 API 응답값으로 교체 필요
+// ⚠️ categoryId, subCategoryId는 백엔드 API 응답값으로 교체 필요
 export const PRODUCT_SUB_CATEGORY_GROUPS: SubcategoryGroup[] = [
   {
+    categoryId: 0,
     categoryLabel: '전체',
     subcategories: [{ subCategoryId: 1, label: '전체' }],
   },
   {
+    categoryId: 1,
     categoryLabel: '스킨케어',
     subcategories: [
-      { subCategoryId: 2, label: '스킨/토너' },
-      { subCategoryId: 3, label: '로션/에멀전' },
-      { subCategoryId: 4, label: '에센스/앰플/세럼' },
-      { subCategoryId: 5, label: '크림' },
-      { subCategoryId: 6, label: '미스트/오일' },
+      { subCategoryId: 101, label: '스킨/토너' },
+      { subCategoryId: 102, label: '로션/에멀전' },
+      { subCategoryId: 103, label: '에센스/앰플/세럼' },
+      { subCategoryId: 104, label: '크림' },
+      { subCategoryId: 105, label: '미스트/오일' },
     ],
   },
   {
+    categoryId: 2,
     categoryLabel: '마스크/팩',
     subcategories: [
-      { subCategoryId: 7, label: '시트 마스크' },
-      { subCategoryId: 8, label: '스킨/토너 패드' },
-      { subCategoryId: 9, label: '코팩' },
-      { subCategoryId: 10, label: '기타 마스크' },
+      { subCategoryId: 201, label: '시트 마스크' },
+      { subCategoryId: 202, label: '스킨/토너 패드' },
+      { subCategoryId: 203, label: '코팩' },
+      { subCategoryId: 204, label: '기타 마스크' },
     ],
   },
   {
+    categoryId: 3,
     categoryLabel: '클렌징',
     subcategories: [
-      { subCategoryId: 11, label: '클렌징 폼' },
-      { subCategoryId: 12, label: '클렌징 오일' },
-      { subCategoryId: 13, label: '클렌징 밤' },
-      { subCategoryId: 14, label: '클렌징 워터/밀크' },
-      { subCategoryId: 15, label: '필링/스크럽' },
+      { subCategoryId: 301, label: '클렌징 폼' },
+      { subCategoryId: 302, label: '클렌징 오일' },
+      { subCategoryId: 303, label: '클렌징 밤' },
+      { subCategoryId: 304, label: '클렌징 워터/밀크' },
+      { subCategoryId: 305, label: '필링/스크럽' },
     ],
   },
   {
+    categoryId: 4,
     categoryLabel: '선케어',
     subcategories: [
-      { subCategoryId: 16, label: '선크림' },
-      { subCategoryId: 17, label: '선앰플' },
+      { subCategoryId: 401, label: '선크림' },
+      { subCategoryId: 402, label: '선앰플' },
     ],
   },
   {
+    categoryId: 5,
     categoryLabel: '베이스 메이크업',
     subcategories: [
-      { subCategoryId: 18, label: '메이크업 베이스' },
-      { subCategoryId: 19, label: '쿠션' },
-      { subCategoryId: 20, label: '파운데이션' },
+      { subCategoryId: 501, label: '메이크업 베이스' },
+      { subCategoryId: 502, label: '쿠션' },
+      { subCategoryId: 503, label: '파운데이션' },
     ],
   },
 ];

--- a/packages/shared/src/types/category.types.ts
+++ b/packages/shared/src/types/category.types.ts
@@ -79,6 +79,7 @@ export interface SubcategoryOption {
 //   subcategories: [
 //     { subCategoryId: 0, label: '스킨/토너' },
 export interface SubcategoryGroup {
+  categoryId: number;
   categoryLabel: string;
   subcategories: SubcategoryOption[];
 }

--- a/packages/shared/src/types/category.types.ts
+++ b/packages/shared/src/types/category.types.ts
@@ -1,4 +1,4 @@
-export interface SubCategoryType {
+export interface SubcategoryType {
   id: number;
   name: string;
 }
@@ -6,7 +6,7 @@ export interface SubCategoryType {
 export interface CategoryType {
   id: number;
   title: string;
-  subCategories?: SubCategoryType[];
+  subCategories?: SubcategoryType[];
 }
 
 type SkinConcern =
@@ -32,7 +32,7 @@ type SkinType =
   | '여드름성'
   | '모르겠음';
 
-type ProductSubCategory =
+type Subcategory =
   | '전체'
   // 스킨케어
   | '스킨/토너'
@@ -70,15 +70,15 @@ export interface SkinTypeOption {
 }
 
 // { subCategoryId: 0, label: '스킨/토너' },
-export interface ProductSubCategoryOption {
+export interface SubcategoryOption {
   subCategoryId: number;
-  label: ProductSubCategory;
+  label: Subcategory;
 }
 // {
 //   categoryLabel: '스킨케어',
 //   subcategories: [
 //     { subCategoryId: 0, label: '스킨/토너' },
-export interface ProductSubCategoryGroup {
+export interface SubcategoryGroup {
   categoryLabel: string;
-  subcategories: ProductSubCategoryOption[];
+  subcategories: SubcategoryOption[];
 }

--- a/packages/shared/src/types/category.types.ts
+++ b/packages/shared/src/types/category.types.ts
@@ -1,12 +1,6 @@
-export interface SubcategoryType {
-  id: number;
-  name: string;
-}
-
 export interface CategoryType {
-  id: number;
-  title: string;
-  subCategories?: SubcategoryType[];
+  categoryId: number;
+  categoryLabel: string;
 }
 
 type SkinConcern =
@@ -69,15 +63,11 @@ export interface SkinTypeOption {
   label: SkinType;
 }
 
-// { subCategoryId: 0, label: '스킨/토너' },
 export interface SubcategoryOption {
   subCategoryId: number;
   label: Subcategory;
 }
-// {
-//   categoryLabel: '스킨케어',
-//   subcategories: [
-//     { subCategoryId: 0, label: '스킨/토너' },
+
 export interface SubcategoryGroup {
   categoryId: number;
   categoryLabel: string;


### PR DESCRIPTION
## 개요

프로젝트 전반에 걸쳐 제품의 분류를 나타내는 명칭이 '제품군(productCategory)', '카테고리(category)' 등으로 혼재되어 있어 일관성이 없었습니다. 이를 `category`로 통일하고, 카테고리 데이터를 `@somesay/shared`의 공유 상수로 일원화하며, 관련 타입 구조를 정리합니다.

## 관련 이슈

Closes #23 

## PR 유형

어떤 변경 사항이 있나요?

- [x] 🔧 코드 리팩토링
- [x] 🧹 코드 외 변경사항 (예: 오타, 탭 사이즈, 변수명 변경 등)
- [x] 📁 파일 또는 폴더명 수정

## 작업 내용

### 1. 용어 통일: `제품군` / `productCategory` → `category`

- `FilterBottomSheet`, `filter.constants.ts`, `filter.types.ts`: `productCategory` 키를 `category`로 rename
- `SubcategoryProductList`: `productCategoryId` → `categoryId`로 rename
- UI 텍스트: 홈 화면 필터 바텀시트의 '제품군' 레이블 → '카테고리'로 변경

### 2. 카테고리 타입 구조 정리 (`packages/shared/src/types/category.types.ts`)

- `SubcategoryType` 제거 (사용처 없음)
- `CategoryType` 단순화: `{ id, title, subCategories? }` → `{ categoryId, categoryLabel }`
- `Subcategory` 유니온 타입 제거 → `SubcategoryOption.label`을 `string`으로 변경 (상수와 이중 관리 해소)
- `SubcategoryGroup`에 `categoryId: number` 추가

### 3. 공유 상수 개선 (`packages/shared/src/constants/cosmetics.constants.ts`)

- `PRODUCT_SUB_CATEGORY_GROUPS` → `CATEGORY_GROUPS`로 rename
- `categoryId: 0, '전체'` 엔트리 제거 — '전체'는 UI 관심사이므로 데이터에서 분리
- 각 카테고리에 `categoryId` 부여 (스킨케어: 1, 마스크/팩: 2, 클렌징: 3, 선케어: 4, 베이스 메이크업: 5)

### 4. 페이지 인라인 상수 제거 → 공유 상수 사용

- `CategoriesPage.tsx`: 인라인 `CATEGORY_MOCK_DATA` 제거, `CATEGORY_GROUPS` import
- `SubcategoriesPage.tsx`: 인라인 `CATEGORY_MOCK_DATA` 제거, `CATEGORY_GROUPS` import 및 `tabSubcategories` 구조 수정

### 5. `CategoryAccordion` 컴포넌트 타입 교체

- props 타입 `CategoryType` → `SubcategoryGroup`으로 교체
- `category.id` → `category.categoryId`, `category.title` → `category.categoryLabel`, `sub.id/name` → `sub.subCategoryId/label`

### 6. `FilterBottomSheet` '전체' 분리

- `ALL_SUBCATEGORY_OPTION` 모듈 상수로 분리 (`subCategoryId: 0`)
- `CATEGORY_GROUPS`로 직접 렌더링, `categoryLabel === '전체'` 분기 제거
- 선택 감지를 `.includes()` 참조 비교 → `.some()` ID 비교로 통일

### 7. `HorizontalCategoriesTab` props 타입 독립화

- `CategoryType` 의존 제거, 로컬 `TabCategoryType({ id, label })`으로 교체
- `mockData.ts`에서 shared와 중복된 `CATEGORIES` 상수 제거
- `CategoryProductSection`에서 `CATEGORIES`를 `TabCategoryType`으로 매핑하여 사용

### 8. 파일명 수정

- `SubCategorySortBar.tsx` → `SubcategorySortBar.tsx` (케이싱 통일)

## 스크린샷/동영상

<img width="417" height="206" alt="image" src="https://github.com/user-attachments/assets/65cac793-df17-4656-abd6-35c5ce033913" />

## 공유사항

- API 연결 시 `CATEGORY_GROUPS`의 ID 값 및 mock 데이터를 실제 응답값으로 교체해야 합니다.
- '전체' 옵션은 각 사용처에서 로컬로 추가하는 방식으로 변경되었습니다.
